### PR TITLE
remove duplicate parameter

### DIFF
--- a/airbnb/api.py
+++ b/airbnb/api.py
@@ -346,7 +346,6 @@ class Api(object):
             'version': '1.4.8',
             'section_offset': '0',
             'items_offset': str(offset),
-            'adults': '0',
             'screen_size': 'small',
             'source': 'explore_tabs',
             'items_per_grid': str(items_per_grid),


### PR DESCRIPTION
The parameter `adults` is duplicated and should be removed